### PR TITLE
CTCP-2751: Remove auditing payload from object-store object

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsauditing/controllers/AuditController.scala
+++ b/app/uk/gov/hmrc/transitmovementsauditing/controllers/AuditController.scala
@@ -24,26 +24,25 @@ import play.api.Logging
 import play.api.http.MimeTypes
 import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import play.api.mvc.Action
 import play.api.mvc.ControllerComponents
 import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.transitmovementsauditing.Payload
 import uk.gov.hmrc.transitmovementsauditing.config.AppConfig
 import uk.gov.hmrc.transitmovementsauditing.config.Constants
 import uk.gov.hmrc.transitmovementsauditing.controllers.stream.StreamingParsers
 import uk.gov.hmrc.transitmovementsauditing.models.AuditType
 import uk.gov.hmrc.transitmovementsauditing.models.FileId
-import uk.gov.hmrc.transitmovementsauditing.models.ObjectStoreResourceLocation
 import uk.gov.hmrc.transitmovementsauditing.models.ObjectSummaryWithFields
 import uk.gov.hmrc.transitmovementsauditing.models.errors.ConversionError
 import uk.gov.hmrc.transitmovementsauditing.models.errors.PresentationError
-import uk.gov.hmrc.transitmovementsauditing.Payload
 import uk.gov.hmrc.transitmovementsauditing.services.AuditService
 import uk.gov.hmrc.transitmovementsauditing.services.ConversionService
-import uk.gov.hmrc.transitmovementsauditing.services.ObjectStoreService
 import uk.gov.hmrc.transitmovementsauditing.services.FieldParsingService
+import uk.gov.hmrc.transitmovementsauditing.services.ObjectStoreService
 
 import java.time.Instant
 import java.time.ZoneOffset
@@ -69,14 +68,14 @@ class AuditController @Inject() (
     with ErrorTranslator
     with Logging {
 
-  def post(auditType: AuditType, uri: Option[ObjectStoreResourceLocation] = None): Action[Source[ByteString, _]] = Action.streamFromFile {
+  def post(auditType: AuditType): Action[Source[ByteString, _]] = Action.streamFromFile {
 
     implicit request =>
       if (appConfig.auditingEnabled) {
         implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
         (for {
-          stream <- getSource(auditType, uri, request)(exceedsMessageSize)
+          stream <- getSource(auditType, request)(exceedsMessageSize)
           result <- auditService.send(auditType, stream).asPresentation
         } yield result)
           .fold(
@@ -91,11 +90,7 @@ class AuditController @Inject() (
   private def exceedsMessageSize(implicit request: Request[Source[ByteString, _]]): Boolean =
     request.headers
       .get(Constants.XContentLengthHeader)
-      .map(_.toLong > appConfig.auditMessageMaxSize)
-      .getOrElse(false)
-
-  def postLarge(auditType: AuditType, uri: String): Action[Source[ByteString, _]] =
-    post(auditType, Some(ObjectStoreResourceLocation(uri).stripRoutePrefix))
+      .exists(_.toLong > appConfig.auditMessageMaxSize)
 
   private def convertIfNecessary(auditType: AuditType, request: Request[Source[ByteString, _]])(implicit
     hc: HeaderCarrier
@@ -108,41 +103,24 @@ class AuditController @Inject() (
   private def fileId(): FileId =
     FileId(s"${UUID.randomUUID().toString}-${DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").withZone(ZoneOffset.UTC).format(Instant.now())}")
 
-  private def getSource(auditType: AuditType, uri: Option[ObjectStoreResourceLocation], request: Request[Source[ByteString, _]])(exceedsLimit: Boolean)(implicit
+  private def getSource(auditType: AuditType, request: Request[Source[ByteString, _]])(exceedsLimit: Boolean)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, PresentationError, Payload] =
-    (uri, exceedsLimit) match {
-      case (None, false) =>
-        logger.info("Payload in body and < auditing message limit")
-        convertIfNecessary(auditType, request).asPresentation
-          .map(Right(_))
-      case (Some(uri), false) =>
-        logger.info("Payload in object store and < auditing message limit")
-        val contents = objectStoreService
-          .getContents(uri)
-          .asPresentation
-        contents.map(Right(_))
-      case (None, true) =>
-        logger.info("Payload in body and > auditing message limit")
-        (for {
-          parseResults <- FieldParsingService.getAdditionalFields(auditType.messageType, request.body).asPresentation
-          keyValuePairs = parseResults.collect {
-            case Right(pair) => pair
-          }
-          objSummary <- objectStoreService.putFile(fileId(), request.body).asPresentation
-        } yield ObjectSummaryWithFields(objSummary, keyValuePairs)).map {
-          summaryWithFields => Left(summaryWithFields)
+    if (exceedsLimit) {
+      logger.info("Payload in body and > auditing message limit")
+      (for {
+        parseResults <- FieldParsingService.getAdditionalFields(auditType.messageType, request.body).asPresentation
+        keyValuePairs = parseResults.collect {
+          case Right(pair) => pair
         }
-      case (Some(uri), true) =>
-        logger.info("Payload in object store and > auditing message limit")
-        for {
-          contents     <- objectStoreService.getContents(uri).asPresentation
-          parseResults <- FieldParsingService.getAdditionalFields(auditType.messageType, request.body).asPresentation
-          keyValuePairs = parseResults.collect {
-            case Right(pair) => pair
-          }
-          objSummary <- objectStoreService.putFile(fileId(), contents).asPresentation
-        } yield Left(ObjectSummaryWithFields(objSummary, keyValuePairs))
+        objSummary <- objectStoreService.putFile(fileId(), request.body).asPresentation
+      } yield ObjectSummaryWithFields(objSummary, keyValuePairs)).map {
+        summaryWithFields => Left(summaryWithFields)
+      }
+    } else {
+      logger.info("Payload in body and < auditing message limit")
+      convertIfNecessary(auditType, request).asPresentation
+        .map(Right(_))
     }
 
 }

--- a/app/uk/gov/hmrc/transitmovementsauditing/models/ObjectStoreResourceLocation.scala
+++ b/app/uk/gov/hmrc/transitmovementsauditing/models/ObjectStoreResourceLocation.scala
@@ -23,6 +23,4 @@ object ObjectStoreResourceLocation {
   implicit lazy val ObjectStoreResourceLocationFormat: Format[ObjectStoreResourceLocation] = Json.format[ObjectStoreResourceLocation]
 }
 
-case class ObjectStoreResourceLocation(value: String) extends AnyVal {
-  def stripRoutePrefix: ObjectStoreResourceLocation = ObjectStoreResourceLocation(value.stripPrefix("uri/"))
-}
+case class ObjectStoreResourceLocation(value: String) extends AnyVal

--- a/app/uk/gov/hmrc/transitmovementsauditing/models/ObjectSummaryWithFields.scala
+++ b/app/uk/gov/hmrc/transitmovementsauditing/models/ObjectSummaryWithFields.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.transitmovementsauditing.models
 
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.Writes
 import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
@@ -25,12 +24,10 @@ case class ObjectSummaryWithFields(objectSummary: ObjectSummaryWithMd5, fields: 
 
 object ObjectSummaryWithFields {
 
-  implicit val objectSummaryWithFieldsWrites = new Writes[ObjectSummaryWithFields] {
-
-    override def writes(o: ObjectSummaryWithFields): JsValue = Json.obj(
+  implicit val objectSummaryWithFieldsWrites: Writes[ObjectSummaryWithFields] = (o: ObjectSummaryWithFields) =>
+    Json.obj(
       "objectSummary"    -> o.objectSummary.toString,
       "additionalFields" -> o.fields.toString()
     )
-  }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,3 @@
 # microservice specific routes
 
 POST        /audit/:auditType           uk.gov.hmrc.transitmovementsauditing.controllers.AuditController.post(auditType: uk.gov.hmrc.transitmovementsauditing.models.AuditType)
-POST        /audit/:auditType/*uri      uk.gov.hmrc.transitmovementsauditing.controllers.AuditController.postLarge(auditType: uk.gov.hmrc.transitmovementsauditing.models.AuditType, uri)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,7 +94,6 @@ metrics {
 
 auditing {
   enabled = true
-  traceRequests = true
   consumer {
     baseUri {
       host = localhost

--- a/test/uk/gov/hmrc/transitmovementsauditing/controllers/ObjectStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsauditing/controllers/ObjectStoreServiceSpec.scala
@@ -74,48 +74,6 @@ class ObjectStoreServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar
 
   "ObjectStoreService" - {
 
-    "on retrieving the object" - {
-
-      "should return the file contents" in {
-        val metadata = ObjectMetadata("", 0, Md5Hash(""), Instant.now(), Map.empty[String, String])
-        val obj      = Option[Object[Source[ByteString, NotUsed]]](Object.apply(File(filePath.value), Source.single(ByteString(fileContents)), metadata))
-
-        when(mockClient.getObject[Source[ByteString, NotUsed]](eqTo(File(filePath.value)), any())(any(), any()))
-          .thenReturn(Future.successful(obj))
-
-        val sut    = new ObjectStoreServiceImpl(appConfig)
-        val result = sut.getContents(filePath).value
-
-        whenReady(result) {
-          _ mustBe Right(obj.get.content)
-        }
-
-      }
-
-      "should return an error when the file is not found in object store" in {
-        when(mockClient.getObject[Source[ByteString, NotUsed]](any[File](), any())(any(), any())).thenReturn(Future.successful(None))
-        val sut    = new ObjectStoreServiceImpl(appConfig)
-        val result = sut.getContents(filePath).value
-
-        whenReady(result) {
-          case Left(FileNotFound(fileName)) => succeed
-          case reason                       => fail(s"Expected Left(FileNotFound), got $reason")
-        }
-      }
-
-      "should return an error when there is a problem getting an object from object store" in {
-        when(mockClient.getObject[Source[ByteString, NotUsed]](any[File](), any())(any(), any()))
-          .thenReturn(Future.failed(UpstreamErrorResponse("failed", INTERNAL_SERVER_ERROR)))
-        val sut    = new ObjectStoreServiceImpl(appConfig)
-        val result = sut.getContents(filePath).value
-
-        whenReady(result) {
-          case Left(UnexpectedError(fileName)) => succeed
-          case reason                          => fail(s"Expected an UnexpectedError, got $reason")
-        }
-      }
-    }
-
     "On putting a file in object store" - {
 
       val source: Source[ByteString, _]       = Source.single(ByteString("<test>test</test>"))


### PR DESCRIPTION
Part 5 of centralising object-store access.

## What is this PR?

This PR removes now dead routes -- we won't be passing object store references to the auditing service.

## Why?

PlatOps asked us to not access object-store from outside the storing service. 

##  What changes are there?

* Removes the object-store uri based route

Regression tests all pass!

## What's next?

Other services will have dead code removed, and `transit-movements` will be switched over to use its own resource location, which will complete this transition.