### PR TITLE
Update extraction logic for ChannelType

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsauditing/models/Metadata.scala
+++ b/app/uk/gov/hmrc/transitmovementsauditing/models/Metadata.scala
@@ -32,5 +32,6 @@ case class Metadata(
   movementType: Option[MovementType],
   messageType: Option[MessageType],
   clientId: Option[ClientId],
-  channel: Option[Channel]
+  channel: Option[Channel],
+  size: Option[Long] = None
 )

--- a/test/uk/gov/hmrc/transitmovementsauditing/controllers/AuditControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsauditing/controllers/AuditControllerSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.transitmovementsauditing.controllers
 
+import cats.data.EitherT
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
-import cats.data.EitherT
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
@@ -50,8 +50,8 @@ import uk.gov.hmrc.transitmovementsauditing.controllers.actions.InternalAuthActi
 import uk.gov.hmrc.transitmovementsauditing.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsauditing.models.AuditType._
 import uk.gov.hmrc.transitmovementsauditing.models.MessageType.IE015
-import uk.gov.hmrc.transitmovementsauditing.models._
 import uk.gov.hmrc.transitmovementsauditing.models.MovementType.Departure
+import uk.gov.hmrc.transitmovementsauditing.models._
 import uk.gov.hmrc.transitmovementsauditing.models.errors.AuditError
 import uk.gov.hmrc.transitmovementsauditing.models.errors.ConversionError
 import uk.gov.hmrc.transitmovementsauditing.models.errors.ParseError
@@ -282,7 +282,7 @@ class AuditControllerSpec
         verify(mockObjectStoreService, times(1)).putFile(FileId(any()), any())(any(), any())
       }
 
-      "returns 202 when auditing was successful When auditSource is common-transit-convention-traders and ClientId is provided than details should contain Channel as API" in {
+      "returns 202 when auditing was successful when ClientId is provided than details should contain Channel as API" in {
 
         when(mockAppConfig.auditMessageMaxSize).thenReturn(50000)
         val argumentCaptor: ArgumentCaptor[Details] = ArgumentCaptor.forClass(classOf[Details])
@@ -299,7 +299,7 @@ class AuditControllerSpec
         verify(mockAuditService, times(1)).sendMessageTypeEvent(eqTo(DeclarationAmendment), any())(any())
       }
 
-      "returns 202 when auditing was successful When auditSource is common-transit-convention-traders and ClientId is not provided than details should contain Channel as WEB" in {
+      "returns 202 when auditing was successful When ClientId is not provided than details should contain Channel as WEB" in {
 
         when(mockAppConfig.auditMessageMaxSize).thenReturn(50000)
         val argumentCaptor: ArgumentCaptor[Details] = ArgumentCaptor.forClass(classOf[Details])
@@ -314,25 +314,6 @@ class AuditControllerSpec
         details.metadata.channel mustBe Some(Channel.Web)
 
         verify(mockAuditService, times(1)).sendMessageTypeEvent(eqTo(DeclarationAmendment), any())(any())
-      }
-
-      "returns 202 when auditing was successful When auditSource is not common-transit-convention-traders and details doesn't contain Channel and ClientId" in {
-
-        when(mockAppConfig.auditMessageMaxSize).thenReturn(50000)
-        when(mockConversionService.toJson(eqTo(MessageType.IE004), any())(any())).thenAnswer(conversionServiceXmlToJsonPartial)
-        val argumentCaptor: ArgumentCaptor[Details] = ArgumentCaptor.forClass(classOf[Details])
-        when(mockAuditService.sendMessageTypeEvent(eqTo(AmendmentAcceptance), argumentCaptor.capture())(any())).thenReturn(EitherT.rightT(()))
-
-        val result = controller.post(AmendmentAcceptance)(fakeRequest)
-        status(result) mustBe Status.ACCEPTED
-
-        val details = argumentCaptor.getValue
-
-        details.metadata.clientId mustBe None
-        details.metadata.channel mustBe None
-
-        verify(mockConversionService, times(1)).toJson(eqTo(MessageType.IE004), any())(any())
-        verify(mockAuditService, times(1)).sendMessageTypeEvent(eqTo(AmendmentAcceptance), any())(any())
       }
 
       "returns 500 when the conversion service fails" in {
@@ -593,7 +574,7 @@ class AuditControllerSpec
         verify(mockAuditService, times(1)).sendMessageTypeEvent(eqTo(DeclarationData), any())(any())
       }
 
-      "returns 202 when auditing was successful When auditSource is common-transit-convention-traders and ClientId is provided than details should contain Channel as API" in {
+      "returns 202 when auditing was successful When ClientId is provided than details should contain Channel as API" in {
         reset(mockAppConfig)
         when(mockAppConfig.auditingEnabled).thenReturn(true)
         when(mockAppConfig.auditMessageMaxSize).thenReturn(50000)
@@ -615,7 +596,7 @@ class AuditControllerSpec
 
       }
 
-      "returns 202 when auditing was successful When auditSource is common-transit-convention-traders and ClientId is not provided than details should contain Channel as WEB" in {
+      "returns 202 when auditing was successful When ClientId is not provided than details should contain Channel as WEB" in {
 
         reset(mockAppConfig)
         when(mockAppConfig.auditingEnabled).thenReturn(true)

--- a/test/uk/gov/hmrc/transitmovementsauditing/models/MetadataSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsauditing/models/MetadataSpec.scala
@@ -39,7 +39,7 @@ class MetadataSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenProper
       val clientId = arbitraryClientId.arbitrary.sample.get
       val channel  = arbitraryChannel.arbitrary.sample.get
       val actual = Metadata.metadataFormat.writes(
-        Metadata(path, Some(movementId), Some(messageId), Some(eoriNumber), Some(movementType), Some(messageType), Some(clientId), Some(channel))
+        Metadata(path, Some(movementId), Some(messageId), Some(eoriNumber), Some(movementType), Some(messageType), Some(clientId), Some(channel), Some(123))
       )
       val expected = Json.obj(
         "path"          -> path,
@@ -49,7 +49,8 @@ class MetadataSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenProper
         "movementType"  -> movementType,
         "messageType"   -> messageType,
         "clientId"      -> clientId,
-        "channel"       -> channel
+        "channel"       -> channel,
+        "size"          -> 123
       )
       actual mustBe expected
   }
@@ -74,10 +75,12 @@ class MetadataSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenProper
           "movementType"  -> movementType,
           "messageType"   -> messageType,
           "clientId"      -> clientId,
-          "channel"       -> channel.channel
+          "channel"       -> channel.channel,
+          "size"          -> 123
         )
       )
-      val expected = Metadata(path, Some(movementId), Some(messageId), Some(eoriNumber), Some(movementType), Some(messageType), Some(clientId), Some(channel))
+      val expected =
+        Metadata(path, Some(movementId), Some(messageId), Some(eoriNumber), Some(movementType), Some(messageType), Some(clientId), Some(channel), Some(123))
       actual mustBe JsSuccess(expected)
   }
 


### PR DESCRIPTION
1. get the clientId and Enrolment number from transit-movements-router call.
2. if the clientId is present in the incoming header then set the channelType to API otherwise set the value as Web.
3.  for NCTSRequestedMissingMovement AuditType Both clientId and ChannelType should be None. So handled the code accordingly.
4. Added new auditing field size and send it to auditing.
5. As per Avdesh we need to contact auditing team only if we are creating new AuditType event. As we have added only new field size to Existing auditType so no need to contact auditing team.